### PR TITLE
feat: add type validation for LLM provider types

### DIFF
--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -21,9 +21,16 @@ var (
 )
 
 type APIKeys struct {
-	TextProvider  textgen.ProviderType
+	TextProvider  string // type checked in internal/user/service.go to textgen.ProviderType
 	TextAPIKey    string
-	ImageProvider imagegen.ProviderType
+	ImageProvider string // type checked in internal/user/service.go to imagegen.ProviderType
+	ImageAPIKey   string
+}
+
+type DecryptAPIKeys struct {
+	TextProvider  textgen.ProviderType // type checked in internal/user/service.go to textgen.ProviderType
+	TextAPIKey    string
+	ImageProvider imagegen.ProviderType // type checked in internal/user/service.go to imagegen.ProviderType
 	ImageAPIKey   string
 }
 

--- a/internal/llm/image/imagegen/factory.go
+++ b/internal/llm/image/imagegen/factory.go
@@ -1,12 +1,27 @@
 package imagegen
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type ProviderType string
 
 const (
 	OpenAI ProviderType = "openai"
 )
+
+var validProviderTypes = map[ProviderType]bool{
+	OpenAI: true,
+}
+
+func NewProviderType(value string) (ProviderType, error) {
+	pt := ProviderType(value)
+	if !validProviderTypes[pt] {
+		return "", errors.New(fmt.Sprintf("%s is not a supported image model", value))
+	}
+	return pt, nil
+}
 
 func NewProvider(providerType ProviderType, apiKey string) (Provider, error) {
 	switch providerType {

--- a/internal/llm/text/textgen/factory.go
+++ b/internal/llm/text/textgen/factory.go
@@ -1,6 +1,9 @@
 package textgen
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type ProviderType string
 
@@ -9,6 +12,23 @@ const (
 	Anthropic    ProviderType = "anthropic"
 	GoogleVertex ProviderType = "google-vertex"
 )
+
+var validProviderTypes = map[ProviderType]bool{
+	OpenAI:       true,
+	Anthropic:    true,
+	GoogleVertex: true,
+}
+
+func NewProviderType(value string) (ProviderType, error) {
+	pt := ProviderType(value)
+	if !validProviderTypes[pt] {
+		return "", errors.New(fmt.Sprintf("%s is not a supported text model", value))
+	}
+	if pt == "google-vertex" {
+		return "", errors.New("support for google gemini coming soon...")
+	}
+	return pt, nil
+}
 
 func NewProvider(providerType ProviderType, apiKey string) (Provider, error) {
 	switch providerType {

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 
 	"github.com/Ibrahim-Haroon/ym-flyer-generator-server.git/internal/encryption"
-	"github.com/Ibrahim-Haroon/ym-flyer-generator-server.git/internal/llm/image/imagegen"
-	"github.com/Ibrahim-Haroon/ym-flyer-generator-server.git/internal/llm/text/textgen"
 	"github.com/Ibrahim-Haroon/ym-flyer-generator-server.git/internal/user/model"
 	"github.com/gin-gonic/gin"
 )
@@ -127,9 +125,9 @@ func (h *Handler) UpdateAPIKeys(c *gin.Context) {
 	}
 
 	keys := &encryption.APIKeys{
-		TextProvider:  textgen.ProviderType(req.TextProvider),
+		TextProvider:  req.TextProvider,
 		TextAPIKey:    req.TextAPIKey,
-		ImageProvider: imagegen.ProviderType(req.ImageProvider),
+		ImageProvider: req.ImageProvider,
 		ImageAPIKey:   req.ImageAPIKey,
 	}
 


### PR DESCRIPTION
- Create NewProviderType functions for both image and text providers to validate input
- Split APIKeys into separate structs for encrypted and decrypted keys
- Add provider type validation when updating API keys in user service
- Remove direct type casting of provider strings in handler